### PR TITLE
Time Rules

### DIFF
--- a/sabrina/sabrina.grammar
+++ b/sabrina/sabrina.grammar
@@ -9,6 +9,8 @@
 (def @queryParam edu.stanford.nlp.sempre.thingtalk.ThingTalk.queryParam)
 (def @actParam edu.stanford.nlp.sempre.thingtalk.ThingTalk.actParam)
 
+(def @timeRule edu.stanford.nlp.sempre.thingtalk.ThingTalk.timeRule)
+
 (def @cmdForm edu.stanford.nlp.sempre.thingtalk.ThingTalk.cmdForm)
 
 (def @jsonOut edu.stanford.nlp.sempre.thingtalk.ThingTalk.jsonOut)
@@ -128,6 +130,8 @@
 
 (rule $Notify (monitor if $Trigger) (IdentityFn))
 
+(rule $TimeRule (every day at $TimeValue $Action) (lambda time (lambda action (call @timeRule (var time) (var action)))))
+
 (rule $Device ($TOKEN) (thingtalk.ThingpediaLexiconFn kind))
 
 (rule $Help (help) (ConstantFn (string generic)) (anchored 1))
@@ -158,4 +162,5 @@
 (rule $ROOT ($Action) (lambda cmd (call @jsonOut (var cmd))))
 (rule $ROOT ($Notify) (lambda cmd (call @jsonOut (var cmd))))
 (rule $ROOT ($Query) (lambda cmd (call @jsonOut (var cmd))))
+(rule $ROOT ($TimeRule) (lambda cmd (call @jsonOut (var cmd))))
 (rule $ROOT ($Special) (lambda spl (call @special (var spl))))

--- a/sabrina/sabrina.grammar
+++ b/sabrina/sabrina.grammar
@@ -1,7 +1,7 @@
 # JavaExecutor Functions
 (def @stringValueCast edu.stanford.nlp.sempre.thingtalk.ThingTalk.stringValueCast)
 (def @numValueCast edu.stanford.nlp.sempre.thingtalk.ThingTalk.numValueCast)
-(def @tempValueCast edu.stanford.nlp.sempre.thingtalk.ThingTalk.tempValueCast)
+(def @measureValueCast edu.stanford.nlp.sempre.thingtalk.ThingTalk.measureValueCast)
 (def @boolValueCast edu.stanford.nlp.sempre.thingtalk.ThingTalk.boolValueCast)
 (def @paramForm edu.stanford.nlp.sempre.thingtalk.ThingTalk.paramForm)
 
@@ -10,6 +10,7 @@
 (def @actParam edu.stanford.nlp.sempre.thingtalk.ThingTalk.actParam)
 
 (def @timeRule edu.stanford.nlp.sempre.thingtalk.ThingTalk.timeRule)
+(def @timeSpanRule edu.stanford.nlp.sempre.thingtalk.ThingTalk.timeSpanRule)
 
 (def @cmdForm edu.stanford.nlp.sempre.thingtalk.ThingTalk.cmdForm)
 
@@ -27,8 +28,16 @@
 (rule $NumParseValue ($PHRASE) (NumberFn) (anchored 1))
 (rule $NumValue ($NumParseValue) (lambda num (call @numValueCast (var num))))
 
-(rule $TempValue ($NumParseValue c) (lambda num (call @tempValueCast (string "C") (var num))))
-(rule $TempValue ($NumParseValue f) (lambda num (call @tempValueCast (string "F") (var num))))
+(rule $MeasureValue ($NumParseValue c) (lambda num (call @measureValueCast (string "C") (var num))))
+(rule $MeasureValue ($NumParseValue f) (lambda num (call @measureValueCast (string "F") (var num))))
+
+(rule $MeasureValue ($NumParseValue s) (lambda num (call @measureValueCast (string "s") (var num))))
+(rule $MeasureValue ($NumParseValue min) (lambda num (call @measureValueCast (string "min") (var num))))
+(rule $MeasureValue ($NumParseValue h) (lambda num (call @measureValueCast (string "h") (var num))))
+(rule $MeasureValue ($NumParseValue day) (lambda num (call @measureValueCast (string "day") (var num))))
+(rule $MeasureValue ($NumParseValue week) (lambda num (call @measureValueCast (string "week") (var num))))
+(rule $MeasureValue ($NumParseValue month) (lambda num (call @measureValueCast (string "mon") (var num))))
+(rule $MeasureValue ($NumParseValue year) (lambda num (call @measureValueCast (string "year") (var num))))
 
 (rule $BoolParseValue (true) (IdentityFn) (anchored 1))
 (rule $BoolParseValue (false) (IdentityFn) (anchored 1))
@@ -61,7 +70,7 @@
 (rule $TimeArg ($ArgName $Op $TimeValue) (lambda arg (lambda op (lambda value (call @paramForm (string "Time") (var arg) (var op) (var value))))))
 (rule $BoolArg ($ArgName $Op $BoolValue) (lambda arg (lambda op (lambda value (call @paramForm (string "Bool") (var arg) (var op) (var value))))))
 (rule $NumArg ($ArgName $NumOp $NumValue) (lambda arg (lambda op (lambda value (call @paramForm (string "Number") (var arg) (var op) (var value))))))
-(rule $TempArg ($ArgName $NumOp $TempValue) (lambda arg (lambda op (lambda value (call @paramForm (string "Measure") (var arg) (var op) (var value))))))
+(rule $MeasureArg ($ArgName $NumOp $MeasureValue) (lambda arg (lambda op (lambda value (call @paramForm (string "Measure") (var arg) (var op) (var value))))))
 
 # Arguments
 (rule $Arg ($StringArg) (thingtalk.FilterInvalidArgFn))
@@ -70,14 +79,14 @@
 (rule $Arg ($TimeArg) (thingtalk.FilterInvalidArgFn))
 (rule $Arg ($BoolArg) (thingtalk.FilterInvalidArgFn))
 (rule $Arg ($NumArg) (thingtalk.FilterInvalidArgFn))
-(rule $Arg ($TempArg) (thingtalk.FilterInvalidArgFn))
+(rule $Arg ($MeasureArg) (thingtalk.FilterInvalidArgFn))
 #(rule $Arg ($StringArg) (IdentityFn))
 #(rule $Arg ($ArrayArg) (IdentityFn))
 #(rule $Arg ($DateArg) (IdentityFn))
 #(rule $Arg ($TimeArg) (IdentityFn))
 #(rule $Arg ($BoolArg) (IdentityFn))
 #(rule $Arg ($NumArg) (IdentityFn))
-#(rule $Arg ($TempArg) (IdentityFn))
+#(rule $Arg ($MeasureArg) (IdentityFn))
 
 # Action Handling
 (rule $ActionName ($PHRASE) (thingtalk.ThingpediaLexiconFn action))
@@ -133,6 +142,7 @@
 (rule $ActionOrQuery ($Action) (IdentityFn))
 (rule $ActionOrQuery ($Query) (IdentityFn))
 (rule $TimeRule (every day at $TimeValue $ActionOrQuery) (lambda time (lambda action (call @timeRule (var time) (var action)))))
+(rule $TimeRule (every $MeasureValue $ActionOrQuery) (lambda time (lambda action (call @timeSpanRule (var time) (var action)))))
 
 (rule $Device ($TOKEN) (thingtalk.ThingpediaLexiconFn kind))
 

--- a/sabrina/sabrina.grammar
+++ b/sabrina/sabrina.grammar
@@ -130,7 +130,9 @@
 
 (rule $Notify (monitor if $Trigger) (IdentityFn))
 
-(rule $TimeRule (every day at $TimeValue $Action) (lambda time (lambda action (call @timeRule (var time) (var action)))))
+(rule $ActionOrQuery ($Action) (IdentityFn))
+(rule $ActionOrQuery ($Query) (IdentityFn))
+(rule $TimeRule (every day at $TimeValue $ActionOrQuery) (lambda time (lambda action (call @timeRule (var time) (var action)))))
 
 (rule $Device ($TOKEN) (thingtalk.ThingpediaLexiconFn kind))
 

--- a/src/edu/stanford/nlp/sempre/thingtalk/RuleValue.java
+++ b/src/edu/stanford/nlp/sempre/thingtalk/RuleValue.java
@@ -1,11 +1,11 @@
 package edu.stanford.nlp.sempre.thingtalk;
 
+import java.util.HashMap;
+import java.util.Map;
+
 import edu.stanford.nlp.sempre.Value;
 import edu.stanford.nlp.sempre.Values;
 import fig.basic.LispTree;
-
-import java.util.HashMap;
-import java.util.Map;
 
 /**
  * Represents a thingtalk rule.
@@ -13,40 +13,76 @@ import java.util.Map;
  */
 public class RuleValue extends Value {
     public final TriggerValue trigger;
+	public final QueryValue query;
     public final ActionValue action;
 
-    public RuleValue(TriggerValue trigger, ActionValue action) {
+	public RuleValue(TriggerValue trigger, QueryValue query, ActionValue action) {
         this.trigger = trigger;
+		this.query = query;
         this.action = action;
     }
     public RuleValue(LispTree tree) {
         this.trigger = (TriggerValue) Values.fromLispTree(tree.child(1));
-        this.action = (ActionValue) Values.fromLispTree(tree.child(2));
+		this.query = (QueryValue) Values.fromLispTree(tree.child(2));
+		this.action = (ActionValue) Values.fromLispTree(tree.child(3));
     }
 
-    public LispTree toLispTree() {
+    @Override
+	public LispTree toLispTree() {
         LispTree tree = LispTree.proto.newList();
         tree.addChild("rule");
         tree.addChild(trigger.toLispTree());
+		tree.addChild(query.toLispTree());
         tree.addChild(action.toLispTree());
         return tree;
     }
 
-    public Map<String,Object> toJson() {
-        Map<String,Object> json = new HashMap<String,Object>();
+    @Override
+	public Map<String,Object> toJson() {
+        Map<String,Object> json = new HashMap<>();
         json.put("trigger", trigger.toJson());
-        json.put("action", action.toJson());
+		if (query != null)
+			json.put("query", query.toJson());
+		if (action != null)
+			json.put("action", action.toJson());
         return json;
     }
 
-    @Override public boolean equals(Object o) {
-        if(this == o) return true;
-        if(o == null || getClass() != o.getClass()) return false;
-        RuleValue that = (RuleValue) o;
-        if(!trigger.equals(that.trigger) || !action.equals(that.action)) return false;
-        return true;
-    }
-    @Override public int hashCode() {
-        return trigger.hashCode() ^ action.hashCode();
-    }
+	// Generated with Eclipse 
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = 1;
+		result = prime * result + ((action == null) ? 0 : action.hashCode());
+		result = prime * result + ((query == null) ? 0 : query.hashCode());
+		result = prime * result + ((trigger == null) ? 0 : trigger.hashCode());
+		return result;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj)
+			return true;
+		if (obj == null)
+			return false;
+		if (getClass() != obj.getClass())
+			return false;
+		RuleValue other = (RuleValue) obj;
+		if (action == null) {
+			if (other.action != null)
+				return false;
+		} else if (!action.equals(other.action))
+			return false;
+		if (query == null) {
+			if (other.query != null)
+				return false;
+		} else if (!query.equals(other.query))
+			return false;
+		if (trigger == null) {
+			if (other.trigger != null)
+				return false;
+		} else if (!trigger.equals(other.trigger))
+			return false;
+		return true;
+	}
 }

--- a/src/edu/stanford/nlp/sempre/thingtalk/ThingTalk.java
+++ b/src/edu/stanford/nlp/sempre/thingtalk/ThingTalk.java
@@ -1,5 +1,6 @@
 package edu.stanford.nlp.sempre.thingtalk;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -117,6 +118,15 @@ public final class ThingTalk {
     //******************************************************************************************************************
     // Constructing the rule value structure
     //******************************************************************************************************************
+	public static RuleValue timeRule(DateValue time, ActionValue action) {
+		ParamNameValue timeName = new ParamNameValue("time", "String", new NameValue("tt:builtin.at"));
+		ParamValue timeParam = new ParamValue(timeName, "Time", "is", time);
+		TriggerValue timeTrigger = new TriggerValue(new NameValue("tt:builtin.at"),
+				Collections.singletonList(timeParam));
+
+		return new RuleValue(timeTrigger, action);
+	}
+
     public static RuleValue ifttt(TriggerValue trigger, ActionValue action) {
         RuleValue ruleVal = new RuleValue(trigger, action);
         return ruleVal;

--- a/src/edu/stanford/nlp/sempre/thingtalk/ThingTalk.java
+++ b/src/edu/stanford/nlp/sempre/thingtalk/ThingTalk.java
@@ -118,19 +118,29 @@ public final class ThingTalk {
     //******************************************************************************************************************
     // Constructing the rule value structure
     //******************************************************************************************************************
-	public static RuleValue timeRule(DateValue time, ActionValue action) {
+	public static RuleValue timeRule(DateValue time, Value action) {
 		ParamNameValue timeName = new ParamNameValue("time", "String", new NameValue("tt:builtin.at"));
 		ParamValue timeParam = new ParamValue(timeName, "Time", "is", time);
 		TriggerValue timeTrigger = new TriggerValue(new NameValue("tt:builtin.at"),
 				Collections.singletonList(timeParam));
 
-		return new RuleValue(timeTrigger, action);
+		if (action instanceof QueryValue)
+			return new RuleValue(timeTrigger, (QueryValue) action, null);
+		else if (action instanceof ActionValue)
+			return new RuleValue(timeTrigger, null, (ActionValue) action);
+		else
+			throw new RuntimeException();
 	}
 
     public static RuleValue ifttt(TriggerValue trigger, ActionValue action) {
-        RuleValue ruleVal = new RuleValue(trigger, action);
+		RuleValue ruleVal = new RuleValue(trigger, null, action);
         return ruleVal;
     }
+
+	public static RuleValue ifttt(TriggerValue trigger, QueryValue action) {
+		RuleValue ruleVal = new RuleValue(trigger, action, null);
+		return ruleVal;
+	}
 
     //******************************************************************************************************************
     // Constructing the rule value structure

--- a/src/edu/stanford/nlp/sempre/thingtalk/ThingTalk.java
+++ b/src/edu/stanford/nlp/sempre/thingtalk/ThingTalk.java
@@ -30,11 +30,12 @@ public final class ThingTalk {
         return numVal;
     }
 
-    public static NumberValue tempValueCast(String unit, Integer value) {
+	public static NumberValue measureValueCast(String unit, Integer value) {
         NumberValue tempVal = new NumberValue(value, unit);
         return tempVal;
     }
-    public static NumberValue tempValueCast(String unit, Double value) {
+
+	public static NumberValue measureValueCast(String unit, Double value) {
         NumberValue tempVal = new NumberValue(value, unit);
         return tempVal;
     }
@@ -122,6 +123,20 @@ public final class ThingTalk {
 		ParamNameValue timeName = new ParamNameValue("time", "String", new NameValue("tt:builtin.at"));
 		ParamValue timeParam = new ParamValue(timeName, "Time", "is", time);
 		TriggerValue timeTrigger = new TriggerValue(new NameValue("tt:builtin.at"),
+				Collections.singletonList(timeParam));
+
+		if (action instanceof QueryValue)
+			return new RuleValue(timeTrigger, (QueryValue) action, null);
+		else if (action instanceof ActionValue)
+			return new RuleValue(timeTrigger, null, (ActionValue) action);
+		else
+			throw new RuntimeException();
+	}
+
+	public static RuleValue timeSpanRule(NumberValue time, Value action) {
+		ParamNameValue timeName = new ParamNameValue("interval", "Measure(s)", new NameValue("tt:builtin.timer"));
+		ParamValue timeParam = new ParamValue(timeName, "Measure", "is", time);
+		TriggerValue timeTrigger = new TriggerValue(new NameValue("tt:builtin.timer"),
 				Collections.singletonList(timeParam));
 
 		if (action instanceof QueryValue)


### PR DESCRIPTION
"every x seconds do something" and "every day at x time do something"
They correspond to builtins @$at and @$timer.

I think we should merge them because:

1) Time rules are special enough that they warrant their own grammar rule

2) Time rules are language builtins so they won't be resolved from thingpedia

3) Time rules are sufficiently different in language structure from other triggers that they don't fit in the "something happens and condition and condition and condition" scheme
(which makes the paraphrasing poorer, probably)

4) Time rules are easy to understand because they fit into a daily routine.
"Wake me up at 7.50. Make me coffee at 8. Get directions to work at 8.30".

5) Time rules are very useful for continuous queries where a trigger is not really meaningful
Think: "monitor if weather changes" vs "every day at 12pm get weather forecast"
They kinda do they same thing but the second one is more explicit.
