### PR TITLE
Replace Map<String, Double> with trove.TObjectDoubleMap<String>

### DIFF
--- a/src/edu/stanford/nlp/sempre/BeamParser.java
+++ b/src/edu/stanford/nlp/sempre/BeamParser.java
@@ -7,6 +7,7 @@ import com.google.common.collect.ImmutableList;
 
 import fig.basic.*;
 import fig.exec.Execution;
+import gnu.trove.map.hash.TObjectDoubleHashMap;
 
 /**
  * A simple bottom-up chart-based parser that keeps the |beamSize| top
@@ -117,7 +118,7 @@ public void infer() {
       // Compute gradient with respect to the predicted derivations
       ensureExecuted();
       if (computeExpectedCounts) {
-        expectedCounts = new HashMap<>();
+        expectedCounts = new TObjectDoubleHashMap<>();
         ParserState.computeExpectedCounts(predDerivations, expectedCounts);
       }
     }

--- a/src/edu/stanford/nlp/sempre/Example.java
+++ b/src/edu/stanford/nlp/sempre/Example.java
@@ -285,9 +285,7 @@ public class Example {
       item.addChild("null");
     item.addChild(deriv.formula.toLispTree());
 
-    HashMap<String, Double> features = new HashMap<>();
-    deriv.incrementAllFeatureVector(1, features);
-    item.addChild(LispTree.proto.newList(features));
+    item.addChild(LispTree.proto.newList(deriv.getFeatureMap()));
 
     return item;
   }

--- a/src/edu/stanford/nlp/sempre/ExampleUtils.java
+++ b/src/edu/stanford/nlp/sempre/ExampleUtils.java
@@ -1,10 +1,13 @@
 package edu.stanford.nlp.sempre;
 
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
 import fig.basic.*;
 import fig.exec.Execution;
-
-import java.io.*;
-import java.util.*;
 
 /**
  * Output examples in various forms.
@@ -68,7 +71,7 @@ public final class ExampleUtils {
           description.addChild(p.L("value", deriv.value.toLispTree()));
           buf.append("\t" + description);
           buf.append("\t" + deriv.compatibility);
-          Map<String, Double> features = deriv.getAllFeatureVector();
+          Map<String, Double> features = deriv.getFeatureMap();
           buf.append("\t");
           boolean first = true;
           for (Map.Entry<String, Double> e : features.entrySet()) {

--- a/src/edu/stanford/nlp/sempre/FloatingParser.java
+++ b/src/edu/stanford/nlp/sempre/FloatingParser.java
@@ -7,6 +7,7 @@ import java.util.*;
 
 import fig.basic.*;
 import fig.exec.Execution;
+import gnu.trove.map.hash.TObjectDoubleHashMap;
 
 /**
  * A FloatingParser builds Derivations according to a Grammar without having to
@@ -361,7 +362,7 @@ class FloatingParserState extends ParserState {
     // Compute gradient with respect to the predicted derivations
     ensureExecuted();
     if (computeExpectedCounts) {
-      expectedCounts = new HashMap<>();
+      expectedCounts = new TObjectDoubleHashMap<>();
       ParserState.computeExpectedCounts(predDerivations, expectedCounts);
     }
 

--- a/src/edu/stanford/nlp/sempre/Learner.java
+++ b/src/edu/stanford/nlp/sempre/Learner.java
@@ -1,13 +1,17 @@
 package edu.stanford.nlp.sempre;
 
 import java.io.PrintWriter;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
 
 import com.google.common.base.Joiner;
 import com.google.common.collect.Maps;
 
 import fig.basic.*;
 import fig.exec.Execution;
+import gnu.trove.map.TObjectDoubleMap;
+import gnu.trove.map.hash.TObjectDoubleHashMap;
 
 /**
  * The main learning loop.  Goes over a dataset multiple times, calling the
@@ -140,7 +144,7 @@ public class Learner {
 
   public void onlineLearnExample(Example ex) {
     LogInfo.begin_track("onlineLearnExample: %s derivations", ex.predDerivations.size());
-    HashMap<String, Double> counts = new HashMap<>();
+    TObjectDoubleMap<String> counts = new TObjectDoubleHashMap<>();
     for (Derivation deriv : ex.predDerivations)
       deriv.compatibility = parser.valueEvaluator.getCompatibility(ex.targetValue, deriv.value);
     ParserState.computeExpectedCounts(ex.predDerivations, counts);
@@ -163,7 +167,7 @@ public class Learner {
             "Processing %s: %s examples", prefix, examples.size());
     LogInfo.begin_track("Examples");
 
-    Map<String, Double> counts = new HashMap<>();
+    TObjectDoubleMap<String> counts = new TObjectDoubleHashMap<>();
     int batchSize = 0;
     for (int e = 0; e < examples.size(); e++) {
 
@@ -272,7 +276,7 @@ public class Learner {
     return res;
   }
 
-  private void updateWeights(Map<String, Double> counts) {
+  private void updateWeights(TObjectDoubleMap<String> counts) {
     StopWatchSet.begin("Learner.updateWeights");
     LogInfo.begin_track("Updating learner weights");
     double sum = 0;
@@ -320,8 +324,7 @@ public class Learner {
         fields.add("iter=" + iter);
         fields.add("group=" + group);
         fields.add("utterance=" + ex.utterance);
-        Map<String, Double> features = new HashMap<>();
-        deriv.incrementAllFeatureVector(1, features);
+        Map<String, Double> features = deriv.getFeatureMap();
         for (String f : features.keySet()) {
           double v = features.get(f);
           fields.add(f + "=" + v);

--- a/src/edu/stanford/nlp/sempre/Master.java
+++ b/src/edu/stanford/nlp/sempre/Master.java
@@ -11,6 +11,8 @@ import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
 
 import fig.basic.*;
+import gnu.trove.map.TObjectDoubleMap;
+import gnu.trove.map.hash.TObjectDoubleHashMap;
 
 /**
  * A Master manages multiple sessions. Currently, they all share the same model,
@@ -240,7 +242,7 @@ public class Master {
 
   private void printDerivation(Derivation deriv) {
     // Print features
-    HashMap<String, Double> featureVector = new HashMap<>();
+    TObjectDoubleMap<String> featureVector = new TObjectDoubleHashMap<>();
     deriv.incrementAllFeatureVector(1, featureVector);
     FeatureVector.logFeatureWeights("Pred", featureVector, builder.params);
 

--- a/src/edu/stanford/nlp/sempre/Parser.java
+++ b/src/edu/stanford/nlp/sempre/Parser.java
@@ -4,6 +4,8 @@ import java.io.PrintWriter;
 import java.util.*;
 
 import fig.basic.*;
+import gnu.trove.map.TObjectDoubleMap;
+import gnu.trove.map.hash.TObjectDoubleHashMap;
 
 ////////////////////////////////////////////////////////////
 
@@ -259,7 +261,7 @@ public abstract class Parser {
     if (correctIndex != -1 && correct != 1) {
       Derivation trueDeriv = predDerivations.get(correctIndex);
       Derivation predDeriv = predDerivations.get(0);
-      HashMap<String, Double> featureDiff = new HashMap<>();
+      TObjectDoubleMap<String> featureDiff = new TObjectDoubleHashMap<>();
       trueDeriv.incrementAllFeatureVector(+1, featureDiff);
       predDeriv.incrementAllFeatureVector(-1, featureDiff);
       String heading = String.format("TopTrue (%d) - Pred (%d) = Diff", correctIndex, 0);

--- a/src/edu/stanford/nlp/sempre/ParserState.java
+++ b/src/edu/stanford/nlp/sempre/ParserState.java
@@ -2,7 +2,9 @@ package edu.stanford.nlp.sempre;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
+
+import fig.basic.*;
+import gnu.trove.map.TObjectDoubleMap;
 
 import fig.basic.*;
 
@@ -38,7 +40,7 @@ public abstract class ParserState {
   public final Evaluation evaluation = new Evaluation();
 
   // If computeExpectedCounts is true (for learning), then fill this out.
-  public Map<String, Double> expectedCounts;
+  public TObjectDoubleMap<String> expectedCounts;
   public double objectiveValue;
 
   // Statistics generated while parsing
@@ -258,7 +260,7 @@ public abstract class ParserState {
    * according to a standard exponential family model over a finite set of derivations.
    * Assume that everything has been executed, and compatibility has been computed.
    */
-  public static void computeExpectedCounts(List<Derivation> derivations, Map<String, Double> counts) {
+  public static void computeExpectedCounts(List<Derivation> derivations, TObjectDoubleMap<String> counts) {
     double[] trueScores;
     double[] predScores;
 

--- a/src/edu/stanford/nlp/sempre/ReinforcementUtils.java
+++ b/src/edu/stanford/nlp/sempre/ReinforcementUtils.java
@@ -1,12 +1,10 @@
 package edu.stanford.nlp.sempre;
 
+import java.util.*;
+
 import fig.basic.MapUtils;
 import fig.basic.NumUtils;
-
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Random;
+import gnu.trove.map.TObjectDoubleMap;
 
 /**
  * Utils for <code>ReinforcementParser</code>
@@ -21,6 +19,14 @@ public final class ReinforcementUtils {
       MapUtils.incr(mutatedMap, prefix + key, addedMap.get(key));
   }
 
+  public static void addToDoubleMap(TObjectDoubleMap<String> mutatedMap, TObjectDoubleMap<String> addedMap,
+      String prefix) {
+    addedMap.forEachEntry((key, value) -> {
+      mutatedMap.adjustOrPutValue(prefix + key, value, value);
+      return true;
+    });
+  }
+
   public static void subtractFromDoubleMap(Map<String, Double> mutatedMap, Map<String, Double> subtractedMap) {
     for (String key : subtractedMap.keySet())
       MapUtils.incr(mutatedMap, key, -1 * subtractedMap.get(key));
@@ -31,11 +37,29 @@ public final class ReinforcementUtils {
       MapUtils.incr(mutatedMap, prefix + key, -1 * subtractedMap.get(key));
   }
 
+  public static void subtractFromDoubleMap(TObjectDoubleMap<String> mutatedMap,
+      TObjectDoubleMap<String> subtractedMap) {
+    subtractFromDoubleMap(mutatedMap, subtractedMap, "");
+  }
+
+  public static void subtractFromDoubleMap(TObjectDoubleMap<String> mutatedMap, TObjectDoubleMap<String> addedMap,
+      String prefix) {
+    addedMap.forEachEntry((key, value) -> {
+      mutatedMap.adjustOrPutValue(prefix + key, -value, -value);
+      return true;
+    });
+  }
+
   public static Map<String, Double> multiplyDoubleMap(Map<String, Double>  map, double factor) {
     Map<String, Double> res = new HashMap<>();
     for (Map.Entry<String, Double> entry: map.entrySet())
       res.put(entry.getKey(), entry.getValue() * factor);
     return res;
+  }
+
+  public static <K> TObjectDoubleMap<K> multiplyDoubleMap(TObjectDoubleMap<K> map, double factor) {
+    map.transformValues((value) -> value * factor);
+    return map;
   }
 
   public static int sampleIndex(Random rand, List<? extends HasScore> scorables, double denominator) {

--- a/src/edu/stanford/nlp/sempre/SempreUtils.java
+++ b/src/edu/stanford/nlp/sempre/SempreUtils.java
@@ -1,9 +1,9 @@
 package edu.stanford.nlp.sempre;
 
-import fig.basic.LogInfo;
-import fig.basic.MapUtils;
-
 import java.util.Map;
+
+import fig.basic.LogInfo;
+import gnu.trove.map.TObjectDoubleMap;
 
 /**
  * Created by joberant on 10/18/14.
@@ -27,8 +27,17 @@ public final class SempreUtils {
     LogInfo.end_track();
   }
 
-  public static void addToDoubleMap(Map<String, Double> mutatedMap, Map<String, Double> addedMap) {
-    for (String key : addedMap.keySet())
-      MapUtils.incr(mutatedMap, key, addedMap.get(key));
+  public static <K> void logMap(TObjectDoubleMap<K> map, String desc) {
+    LogInfo.begin_track("Logging %s map", desc);
+    for (K key : map.keySet())
+      LogInfo.log(key + "\t" + map.get(key));
+    LogInfo.end_track();
+  }
+
+  public static <K> void addToDoubleMap(TObjectDoubleMap<K> mutatedMap, TObjectDoubleMap<K> addedMap) {
+    addedMap.forEachEntry((key, value) -> {
+      mutatedMap.adjustOrPutValue(key, value, value);
+      return true;
+    });
   }
 }

--- a/src/edu/stanford/nlp/sempre/overnight/OvernightFeatureComputer.java
+++ b/src/edu/stanford/nlp/sempre/overnight/OvernightFeatureComputer.java
@@ -9,9 +9,9 @@ import com.google.common.collect.Sets;
 import edu.stanford.nlp.io.IOUtils;
 import edu.stanford.nlp.sempre.*;
 import edu.stanford.nlp.sempre.LanguageInfo.LanguageUtils;
-import fig.basic.BipartiteMatcher;
-import fig.basic.LogInfo;
-import fig.basic.Option;
+import fig.basic.*;
+import gnu.trove.map.TObjectDoubleMap;
+import gnu.trove.map.hash.TObjectDoubleHashMap;
 
 /**
  * Define features on the input utterance and a partial canonical utterance.
@@ -302,7 +302,7 @@ public final class OvernightFeatureComputer implements FeatureComputer {
     }
 
     if (opts.verbose >= 1) {
-      HashMap<String, Double> features = new LinkedHashMap<>();
+      TObjectDoubleMap<String> features = new TObjectDoubleHashMap<>();
       deriv.incrementAllFeatureVector(+1, features);
       LogInfo.logs("category %s, %s %s", deriv.cat, inputItems, candidateItems);
       FeatureVector.logFeatures(features);


### PR DESCRIPTION
Do this replacement for FeatureVector and Params, which have hot
code that manipulates these maps. The other changes are just to
make it compile.

---

With the flattening stuff in master, which causes us to generate and featurize a lot more derivations, this is increasingly important.
With the master numbers (which are heavily cut compared to what we used to have), I get 3.8~4 sec avg parsing time on crowdie.
After the patch, it's 700 ms (with hot caches), and we no longer hit the GC, causing us to waste time and drop the caches.
